### PR TITLE
Api einkaufsarchiv

### DIFF
--- a/src/backend/share_shop_api.py
+++ b/src/backend/share_shop_api.py
@@ -96,8 +96,9 @@ class Einkaufsarchiv(Base):
 
 class EingekaufteProdukte(Base):
     __tablename__ = "eingekaufte_Produkte"
-    einkauf_id = Column(Integer, ForeignKey("Einkaufsarchiv.einkauf_id", ondelete="CASCADE"), primary_key=True) # AUTO_INCREMENT in DB
-    produkt_id = Column(Integer, ForeignKey("Produkt.id"), primary_key=True)
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    einkauf_id = Column(Integer, ForeignKey("Einkaufsarchiv.einkauf_id", ondelete="CASCADE"), nullable=False)
+    produkt_id = Column(Integer, ForeignKey("Produkt.id"), nullable=False)
     produkt_menge = Column(Numeric(10, 2), nullable=True)
     einheit_id = Column(Integer, ForeignKey("Einheiten.id"), nullable=True)
     produkt_preis = Column(Numeric(10, 2), nullable=True)
@@ -1026,6 +1027,8 @@ def delete_produkt_in_liste(listen_id: int = Path(..., gt=0), produkt_id: int = 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
+# Einkaufsarchiv ------------------------------------
+
 @app.get("/einkaufsarchiv/list/{listen_id}", response_model=List[EinkaufsarchivRead])
 def get_einkaufsarchiv(listen_id: int = Path(..., gt=0), db: Session = Depends(get_db)):
 
@@ -1091,6 +1094,8 @@ def delete_einkaufsarchiv(listen_id: int = Path(..., gt=0), db: Session = Depend
     db.commit()
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+# eingekaufte Produkte ------------------------------------
 
 @app.get("/eingekaufte_produkte/einkauf/{einkauf_id}", response_model=List[eingekaufteProdukteRead])
 def get_eingekaufte_produkte(einkauf_id: int = Path(..., gt=0), db: Session = Depends(get_db)):


### PR DESCRIPTION
Es wurden die Funktionen für das Einkaufsarchiv erstellt (Das zeigt die Einkäufe für eine Liste an)
Es wurden die Funktionen für die eingekauften Produkte erstellt (Das zeigt die Produkte zu den Einkäufen, wenn man im Frontend einen Einkauf anklickt). Die eingekauften Produkte werden durch FK-Beziehung "ON DELETE CASCADE" automatisch gelöscht, wenn der Einkauf gelöscht wird.

Bezüglich der FK's bei den eingekauften Produkten steht etwas in der letzten Commit-Message (war jetzt das sinnvollste was mir in den Kopf kam)

Zusätzlich: kleine Anpassung bei Bedarfsvorhersage (erstmal nicht wichtig, da das eh noch getestet werden muss)