### PR TITLE
Einheit abwählen

### DIFF
--- a/src/frontend/shareshop_4b/src/components/ProductDetail.vue
+++ b/src/frontend/shareshop_4b/src/components/ProductDetail.vue
@@ -15,7 +15,7 @@
       <div class="form-group">
         <label for="einheit">Einheit:</label>
         <select id="einheit" v-model="einheit">
-          <option :value="0">Keine Angabe</option>
+          <option value="">Keine Angabe</option>
           <option v-for="e in einheiten" :key="e.id" :value="e.id">{{ e.name }}</option>
         </select>
       </div>
@@ -47,7 +47,7 @@ export default {
       name: "",
       beschreibung: "",
       menge: "",
-      einheit: "0",
+      einheit: 0,
       hinzugefügt_von: null,
       einheiten: [],
       errorMessage: "",


### PR DESCRIPTION
Issues: #293 #295 
Wesentliche Ändeurngen:

1. Keine Angabe statt "Bitte wählen". Als standard festgelegt, wenn nicht ausgewählt wird
2. Einheit kann abgewählt werden -> (Anahnd "keine Angabe")
3. Fehler bei Valdierung behoben:
 2.1 Problemerläuterung: bei Wiederaufrufen des Produktes und erneutem Speichern tirrt Fehlermeldung auf
 2.2 Beseitigung:  Menge zuerst als Zahl behandeln

